### PR TITLE
Added a TODO which returns the context's expected type

### DIFF
--- a/Sources/TODO/TODO.swift
+++ b/Sources/TODO/TODO.swift
@@ -16,3 +16,14 @@
 public func TODO(_ message: StringLiteralType = "Not yet implemented") -> Never {
     fatalError("TODO: \(message)")
 }
+
+
+/// This immediately crashes. Use this when you haven't yet completed something, but you want it to compile because you
+/// want to test something else.
+///
+/// - Parameter message: _optional_ - The message to associate with the crash. Defaults to `"Not yet implemented"`
+/// - Returns: Never returns, but the compile-time type matches whatever you contextually need where this call is made
+@inlinable
+public func TODO<T>(_ message: String = "Not yet implemented") -> T {
+    fatalError("TODO: \(message)")
+}


### PR DESCRIPTION
This is for when you use it in a place where `Never` is inappropriate, but you still aren't done writing an implementation, like this:

```swift
func magic() -> String {
    TODO()
}
```

Before this PR, the above code sample wouldn't compile, complaining that:

```plain
File.swift:2:4: Cannot convert return expression of type 'Never' to return type 'String'
```

After this PR, it compiles just fine, and crashes as expected